### PR TITLE
Fix #387: Pass pickled attributes, err and out on failure

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,4 @@
  * Niko Wenselowski - https://github.com/okin
  * Jan Felix Langenbach - o <dot> hase3 <at> gmail <dot> com
  * Facundo Ciccioli - facundofc <at> gmail <dot> com
+ * Alexandre Allard - https://github.com/alexandre-allard-scality

--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ Changes
 - python 3.9 support
 - Fix #381: Allow Delayed tasks to be executed multiple times in same process.
 - Fix #382: TaskResult make sure `started` include microsecond as decimal number.
+- Fix #387: Pass pickled attributes, err and out when a task fails in multi processes context.
 
 
 0.33.1 (*2020-09-04*)


### PR DESCRIPTION
Squashed commit of the following:

commit 2716ba9299440c0c9c9c69119aa81d04b7c2f251
Author: Eduardo Schettino <schettino72@gmail.com>
Date:   Sun Apr 4 09:39:13 2021 +0800

    refs 387 pass out/err on multiprocess failure: add test for task failure.

commit 61abf70e7ee29051ed7329dd3e331b34d2f95e34
Author: Alexandre Allard <alexandre.allard@scality.com>
Date:   Wed Mar 31 09:51:02 2021 +0200

    Add CHANGES and AUTHORS entries for #387

commit 08c1491f706a3ce5eeac487f042f50f97875e886
Author: Alexandre Allard <alexandre.allard@scality.com>
Date:   Wed Mar 31 14:57:41 2021 +0200

    Add tests to check pickled attributes, err and out are returned

    Refs: #387

commit 658578f780d436c69316e4552ccf6b4ae2dd347e
Author: Alexandre Allard <alexandre.allard@scality.com>
Date:   Tue Mar 30 20:30:28 2021 +0200

    Pass pickled attributes, err and out on failure

    In multi processes context, the pickled attributes,
    stderr and stdout were not returned in case of
    TaskError or TaskFailed, thus making it hard to see
    what gone wrong when a command exits in error.

    Refs: #387